### PR TITLE
Add custom colors for Games

### DIFF
--- a/apps/custom-colors/video-games.html
+++ b/apps/custom-colors/video-games.html
@@ -54,6 +54,33 @@
             'Activision': 'silver',
             'Sony Computer Entertainment': '#EDA802',
             'Ubisoft': '#512DA8'
+          },
+          'Game': {
+            'Wii Sports': '#005BAA',
+            'Grand Theft Auto V': 'silver',
+            'Super Mario Bros.': '#EDA802',
+            'Tetris': '#512DA8',
+            'Mario Kart Wii': 'green',
+            'FIFA 15': 'silver',
+            'Battlefield 3': '#DE0000',
+            'FIFA 14': '#EDA802',
+            'FIFA 16': '#512DA8',
+            'FIFA Soccer 13': 'green',
+            'Call of Duty: Modern Warfare 3': '#DE0000',
+            'Call of Duty: Black Ops II': '#005BAA',
+            'Call of Duty: Black Ops': '#EDA802',
+            'Call of Duty: Ghosts': '#512DA8',
+            'Call of Duty: Black Ops 3': 'green',
+            'Gran Turismo 3: A-Spec': '#DE0000',
+            'Gran Turismo 4': '#005BAA',
+            'Gran Turismo': 'silver',
+            'Gran Turismo 5': '#512DA8',
+            'Final Fantasy VII': 'green',
+            "Assassin's Creed IV: Black Flag": '#DE0000',
+            "Assassin's Creed III": '#005BAA',
+            'Just Dance III': 'silver',
+            "Assassin's Creed II": '#EDA802',
+            "Assassin's Creed": 'green'
           }
         });
       }

--- a/build/custom-colors/index.html
+++ b/build/custom-colors/index.html
@@ -54,6 +54,33 @@
             'Activision': 'silver',
             'Sony Computer Entertainment': '#EDA802',
             'Ubisoft': '#512DA8'
+          },
+          'Game': {
+            'Wii Sports': '#005BAA',
+            'Grand Theft Auto V': 'silver',
+            'Super Mario Bros.': '#EDA802',
+            'Tetris': '#512DA8',
+            'Mario Kart Wii': 'green',
+            'FIFA 15': 'silver',
+            'Battlefield 3': '#DE0000',
+            'FIFA 14': '#EDA802',
+            'FIFA 16': '#512DA8',
+            'FIFA Soccer 13': 'green',
+            'Call of Duty: Modern Warfare 3': '#DE0000',
+            'Call of Duty: Black Ops II': '#005BAA',
+            'Call of Duty: Black Ops': '#EDA802',
+            'Call of Duty: Ghosts': '#512DA8',
+            'Call of Duty: Black Ops 3': 'green',
+            'Gran Turismo 3: A-Spec': '#DE0000',
+            'Gran Turismo 4': '#005BAA',
+            'Gran Turismo': 'silver',
+            'Gran Turismo 5': '#512DA8',
+            'Final Fantasy VII': 'green',
+            "Assassin's Creed IV: Black Flag": '#DE0000',
+            "Assassin's Creed III": '#005BAA',
+            'Just Dance III': 'silver',
+            "Assassin's Creed II": '#EDA802',
+            "Assassin's Creed": 'green'
           }
         });
       }


### PR DESCRIPTION
Here I've added custom colors for each of the games so that each pie chart has custom colors as well. In each case I made sure to use different colors than the one used in the timeseries (i.e. Nintendo is red so all the Nintendo games use non-red colors). I'm not in love with the palette (I needed to add a sixth color so I used straight-up `green`) so please modify that aspect at will.